### PR TITLE
Fix vercel build runtime error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,13 +9,13 @@
     "NEXT_PUBLIC_WS_URL": "wss://notificacoes-internas.vercel.app"
   },
   "functions": {
-    "pages/api/socket.js": {
-      "runtime": "nodejs18.x"
+    "pages/api/socket.ts": {
+      "maxDuration": 30
     }
   },
   "rewrites": [
     {
-      "source": "/socket.io/(.*)",
+      "source": "/socket.io/:path*",
       "destination": "/api/socket"
     }
   ],


### PR DESCRIPTION
Fix Vercel deployment error by correcting function runtime configuration and file reference in `vercel.json`.

The Vercel build failed because `vercel.json` specified an invalid runtime format (`nodejs18.x`) for a function and referenced the wrong file extension (`.js` instead of `.ts`). Removing the explicit runtime (as Vercel auto-detects) and correcting the file path resolves the error. Additionally, the rewrite pattern for `socket.io` was updated for better consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-18a7778c-0f3e-4b67-a935-2e62c363c449">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-18a7778c-0f3e-4b67-a935-2e62c363c449">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

